### PR TITLE
refacto: almost the same but better

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,34 @@
 # alerts-validator
 
-Define which Prometheus alert has no DataPoint over different time range: 1 day, 30 days, and 90 days.
+This project aims to define if currently used alerting rules in Victoria Metrics are valid.
 
-Continuous loop wich get alerts from Alert endpoint, then analyze them with Select endpoint.
+By valid, we mean that alerting rules should use metrics that are still available, and fire if needed.
+
+A metric could disappear or be renamed after upgrading an infracstructre's component. Alerts-validator help us to have up-to-date alerting rules.
+
+This project has a continuous loop which get alerting rules from VM Alert endpoint, then analyze them with VM Select endpoint, and expose them as Prometheus Metric.
+
+## Example
+
+Let's say you are using this alerting rule (from [Awesome Prometheus Alerts](https://awesome-prometheus-alerts.grep.to/rules.html#rule-host-and-hardware-1-1)) : 
+
+```
+- alert: HostOutOfMemory
+  expr: node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes * 100 < 10
+```
+
+Let's say `node_memory_MemAvailable_bytes` as been renamed because of an upgrade of Prometheus Node Exporter last week.
+
+Alerts-validator will analyze every metric's previous rules by querying VM Select endpoint :
+
+```
+present_over_time(node_memory_MemAvailable_bytes[167h]) offset 1h   --> No datapoints
+present_over_time(node_memory_MemTotal_bytes[167h]) offset 1h       --> Some datapoints
+```
+
+If one of those metrics doesn't have any datapoints, the alerting rule `HostOutOfMemory` will be define as invalid for time range [1h-168h].
+
+You can now be alerted that `HostOutOfMemory` alerting rule need to be updated.
 
 ## Build
 
@@ -12,15 +38,7 @@ GOOS=linux GOARCH=amd64 go build -o alerts-validator-linux-amd64
 
 ## Compatibility
 
-Works with Victoria Metrics v1.76.0
-
-## Metrics
-
-```
-alertsvalidator_present_over_1day
-alertsvalidator_present_over_30days
-alertsvalidator_present_over_90days
-```
+Works from Victoria Metrics v1.76.0 to last
 
 ## Configuration
 
@@ -37,12 +55,57 @@ Usage of alerts-validator:
 ```yaml
 listenAddress: 0.0.0.0      # Listen address for metrics endpoint
 listenPort: 9345            # Listen port for metrics endpoint
-interval: 10                # Interval between 2 compute in minutes
-
+computeInterval: 168h       # Interval between 2 computes (Valid time units are "s", "m", "h". )
+validityCheckIntervals:     # Check if there are datapoints betwen 2 intervals (Valid time units are "s", "m", "h". )
+- 1h
+- 168h
+labelKeys:
+- tenant
 servers:
-  - tenant: "my_tenant"                                             # Added in metric label
-    alertUrl: https://vmalert.cluster.local.                        # Endpoint to get alerts
-    selectUrl: https://vm.cluster.local./select/000/prometheus      # Endpoint to validate metrics
+  - labelValues:                                                   # Added in metric label
+    - my_tenant
+    alertUrl: https://vmalert.cluster.local.                       # Endpoint to get alerts
+    selectUrl: https://vm.cluster.local./select/000/prometheus     # Endpoint to validate metrics
+```
+
+## Metrics
+
+With config :
+
+```yaml
+validityCheckIntervals:
+- 1h
+- 168h
+- 672h
+```
+
+```
+alertsvalidator_validity_range{range_from="1h",range_to="168h",alertname="my_alert"} 0 # Invalid
+alertsvalidator_validity_range{range_from="168h",range_to="672h",alertname="my_alert"} 1 # Valid
+```
+
+## Logs
+
+Some logs are available, they display more informations on alert-validators previous metrics.
+
+```json
+{
+    "level": "info",
+    "alertname": "myInvalidAlert",
+    "is_vector_present": {
+        "1h-168h": {
+            "up{instance=\"my_server\"}": true,
+        },
+        "168h-672h": {
+            "up{instance=\"my_server\"}": false,
+        },
+    },
+    "is_valid": {
+        "1h-168h": true,
+        "168h-672h": false,
+    },
+    "time": ---
+}
 ```
 
 ## Contributors

--- a/config.yaml
+++ b/config.yaml
@@ -1,7 +1,14 @@
 listenAddress: 0.0.0.0      # Listen address for metrics endpoint
 listenPort: 9345            # Listen port for metrics endpoint
-interval: 10                # Interval between 
+computeInterval: 168h       # Interval between 2 computes
+validityCheckIntervals:
+- 1h
+- 168h
+- 672h
+labelKeys:
+- tenant
 servers:
-  - tenant: "my_tenant"                                             # Added in metric label
+  - labelValues:                                                   # Added in metric label
+    - my_tenant                                             
     alertUrl: https://vmalert.cluster.local.                        # Endpoint to get alerts
     selectUrl: https://vm.cluster.local./select/000/prometheus      # Endpoint to validate metrics

--- a/go.mod
+++ b/go.mod
@@ -3,13 +3,15 @@ module t-falconnet/alerts-validator
 go 1.17
 
 require (
+	github.com/VictoriaMetrics/metricsql v0.41.0
+	github.com/prometheus/client_golang v1.12.1
 	github.com/prometheus/prometheus v1.8.2
+	github.com/rs/zerolog v1.27.0
 	gopkg.in/yaml.v2 v2.4.0
 )
 
 require (
 	github.com/VictoriaMetrics/metrics v1.18.1 // indirect
-	github.com/VictoriaMetrics/metricsql v0.41.0 // indirect
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
 	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
@@ -17,9 +19,10 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db // indirect
 	github.com/konsorten/go-windows-terminal-sequences v1.0.3 // indirect
+	github.com/mattn/go-colorable v0.1.12 // indirect
+	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
-	github.com/prometheus/client_golang v1.12.1 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.32.1 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -58,6 +58,7 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5P
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
+github.com/coreos/go-systemd/v22 v22.3.3-0.20220203105225-a9a7ef127534/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
@@ -75,6 +76,7 @@ github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -152,6 +154,10 @@ github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFB
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/mattn/go-colorable v0.1.12 h1:jF+Du6AlPIjs2BiUiQlKOX0rt3SujHxPnksPKZbaA40=
+github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
+github.com/mattn/go-isatty v0.0.14 h1:yVuAays6BHfxijgZPzw+3Zlu5yQgKGP2/hcQbHb7S9Y=
+github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -198,6 +204,9 @@ github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/prometheus v1.8.2 h1:PAL466mnJw1VolZPm1OarpdUpqukUy/eX4tagia17DM=
 github.com/prometheus/prometheus v1.8.2/go.mod h1:oAIUtOny2rjMX0OWN5vPR5/q/twIROJvdqnQKDdil/s=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/rs/xid v1.3.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
+github.com/rs/zerolog v1.27.0 h1:1T7qCieN22GVc8S4Q2yuexzBb1EqjbgjSH9RohbMjKs=
+github.com/rs/zerolog v1.27.0/go.mod h1:7frBqO0oezxmnO7GF86FY++uy8I0Tk/If5ni1G9Qc0U=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.6.0 h1:UBcNElsrwanuuMsnGSlYmtmgbb23qDR5dG+6X6Oo89I=
@@ -341,6 +350,8 @@ golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9 h1:XfKQ4OlFl8okEOr5UvAqFRVj8pY/4yfcXrddB8qAbU0=
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/main.go
+++ b/main.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"os"
 	"strings"
@@ -18,6 +17,9 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"gopkg.in/yaml.v2"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 )
 
 type HTTPClient interface {
@@ -25,16 +27,18 @@ type HTTPClient interface {
 }
 
 type Config struct {
-	ListenAddress string   `yaml:"listenAddress"`
-	ListenPort    int      `yaml:"listenPort"`
-	Interval      int      `yaml:"interval"`
-	Servers       []Server `yaml:"servers"`
+	ListenAddress          string   `yaml:"listenAddress"`
+	ListenPort             int      `yaml:"listenPort"`
+	ComputeInterval        string   `yaml:"computeInterval"`
+	ValidityCheckIntervals []string `yaml:"validityCheckIntervals"`
+	Servers                []Server `yaml:"servers"`
+	LabelKeys              []string `yaml:"labelKeys"`
 }
 
 type Server struct {
-	Tenant    string `yaml:"tenant"`
-	AlertURL  string `yaml:"alertUrl"`
-	SelectURL string `yaml:"selectUrl"`
+	LabelValues []string `yaml:"labelValues"`
+	AlertURL    string   `yaml:"alertUrl"`
+	SelectURL   string   `yaml:"selectUrl"`
 }
 
 type Groups struct {
@@ -61,81 +65,71 @@ type Query struct {
 var (
 	vectors []string
 	Client  HTTPClient
-
-	metric_present_1_day = promauto.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "alertsvalidator_present_over_1day",
-			Help: "does the alert's metrics contains data point over 1 day",
-		},
-		[]string{
-			"tenant",
-			"alertname",
-		},
-	)
-	metric_present_30_days = promauto.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "alertsvalidator_present_over_30days",
-			Help: "does the alert's metric contains data point over the last 30 days",
-		},
-		[]string{
-			"tenant",
-			"alertname",
-		},
-	)
-	metric_present_90_days = promauto.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "alertsvalidator_present_over_90days",
-			Help: "does the alert's metric contains data point over the last 90 days",
-		},
-		[]string{
-			"tenant",
-			"alertname",
-		},
-	)
+	gauge   *prometheus.GaugeVec
+	config  Config
 )
 
 func main() {
+	zerolog.TimeFieldFormat = zerolog.TimeFormatUnix
 	confPath := flag.String("conf", "config.yaml", "Config path")
+	debug := flag.Bool("debug", false, "sets log level to debug")
 	flag.Parse()
 
-	config := loadConf(*confPath)
+	zerolog.SetGlobalLevel(zerolog.InfoLevel)
+	if *debug {
+		zerolog.SetGlobalLevel(zerolog.DebugLevel)
+	}
+
+	config = *loadConf(*confPath)
 	listenAddress := config.ListenAddress
 	listenPort := config.ListenPort
-	interval := config.Interval
 
 	// Init http client
 	Client = &http.Client{}
 
+	// Build Gauges
+	gauge = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "alertsvalidator_validity_range",
+			Help: "Does the alert's metric contains data point in range",
+		},
+		append([]string{
+			"alertname",
+			"range_from",
+			"range_to",
+		}, config.LabelKeys...),
+	)
+
 	for _, server := range config.Servers {
-		go checkRules(server, interval)
+		go checkRules(server)
 	}
 
-	log.Println("Listening on " + listenAddress + ":" + fmt.Sprint(listenPort) + "/metrics")
+	log.Info().Msgf("Listening on %s:%d/metrics", listenAddress, listenPort)
 	http.Handle("/metrics", promhttp.Handler())
 	prometheus.Unregister(collectors.NewGoCollector())
 	prometheus.Unregister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
 	err := http.ListenAndServe(listenAddress+":"+fmt.Sprint(listenPort), nil)
 	if err != nil {
-		log.Fatalln(err)
+		log.Fatal().Err(err).Msg("Cant launch metric server")
 	}
 }
 
 func loadConf(confPath string) *Config {
 	yamlFile, err := ioutil.ReadFile(confPath)
 	if err != nil {
-		log.Printf("yamlFile.Get err #%v ", err)
+		log.Fatal().Err(err).Msg("Can't read config file")
 		os.Exit(1)
 	}
 	var c Config
 	err = yaml.Unmarshal(yamlFile, &c)
 	if err != nil {
-		log.Fatalf("Unmarshal: %v", err)
+		log.Fatal().Err(err).Msg("Unmarshal error")
 		os.Exit(1)
 	}
 	return &c
 }
 
-func checkRules(server Server, interval int) {
+func checkRules(server Server) {
 	for {
 		groups := getRules(server.AlertURL)
 		for _, group := range groups.Data.Groups {
@@ -150,23 +144,71 @@ func checkRules(server Server, interval int) {
 				if err != nil {
 					continue
 				}
-				for _, vector := range vectors {
-					metric_present_1_day.WithLabelValues(server.Tenant, rule.Name).Set(1)
-					metric_present_30_days.WithLabelValues(server.Tenant, rule.Name).Set(1)
-					metric_present_90_days.WithLabelValues(server.Tenant, rule.Name).Set(1)
-					if !existingMetric(vector, server.SelectURL) {
-						if !existingMetric("present_over_time("+vector+"[30d])", server.SelectURL) {
-							if !existingMetric("present_over_time("+vector+"[90d])", server.SelectURL) {
-								metric_present_90_days.WithLabelValues(server.Tenant, rule.Name).Set(0)
-							}
-							metric_present_30_days.WithLabelValues(server.Tenant, rule.Name).Set(0)
-						}
-						metric_present_1_day.WithLabelValues(server.Tenant, rule.Name).Set(0)
+				zDictVectorPresent := zerolog.Dict()
+				zDictValid := zerolog.Dict()
+				for key, interval := range config.ValidityCheckIntervals {
+					zDictVector := zerolog.Dict()
+					if key >= len(config.ValidityCheckIntervals)-1 {
+						continue
 					}
+					checkedVector := []string{}
+					valid := true
+					for _, vector := range vectors {
+						checked := false
+						for _, v := range checkedVector {
+							if v == vector {
+								checked = true
+							}
+						}
+						if checked {
+							continue
+						} else {
+							checkedVector = append(checkedVector, vector)
+						}
+						dur1, err := time.ParseDuration(config.ValidityCheckIntervals[key+1])
+						if err != nil {
+							log.Error().Err(err).Msg("Something is wrong with Validity Check Intervals")
+							os.Exit(1)
+						}
+						dur2, err := time.ParseDuration(interval)
+						if err != nil {
+							log.Error().Err(err).Msg("Something is wrong with Validity Check Intervals")
+							os.Exit(1)
+						}
+						dur := time.Until(time.Now().Add(dur1).Add(-dur2))
+						check := fmt.Sprintf("present_over_time(%s[%s]) offset %s", vector, dur.String(), interval)
+						_, err = metricsql.Parse(check)
+						if err != nil {
+							log.Error().Err(err).Str("check", check).Msg("Something is wrong with Validity Check Intervals")
+							os.Exit(1)
+						}
+						log.Debug().Str("alertname", rule.Name).Str("check", check).Send()
+						if !existingMetric(check, server.SelectURL) {
+							zDictVector.Bool(vector, false)
+							valid = false
+						} else {
+							zDictVector.Bool(vector, true)
+						}
+					}
+					labels := append([]string{rule.Name, interval, config.ValidityCheckIntervals[key+1]}, server.LabelValues...)
+					if !valid {
+						gauge.WithLabelValues(labels...).Set(0)
+						zDictValid.Bool(fmt.Sprintf("%s-%s", interval, config.ValidityCheckIntervals[key+1]), false)
+					} else {
+						gauge.WithLabelValues(labels...).Set(1)
+						zDictValid.Bool(fmt.Sprintf("%s-%s", interval, config.ValidityCheckIntervals[key+1]), true)
+					}
+					zDictVectorPresent.Dict(fmt.Sprintf("%s-%s", interval, config.ValidityCheckIntervals[key+1]), zDictVector)
 				}
+				log.Info().Str("alertname", rule.Name).Dict("is_vector_present", zDictVectorPresent).Dict("is_valid", zDictValid).Send()
 			}
 		}
-		time.Sleep(time.Duration(interval) * time.Minute)
+		dur, err := time.ParseDuration(config.ComputeInterval)
+		if err != nil {
+			log.Fatal().Err(err).Msg("Can't parse Compute Interval")
+			os.Exit(0)
+		}
+		time.Sleep(dur)
 	}
 }
 
@@ -178,18 +220,23 @@ func getRules(server string) Groups {
 	var gr Groups
 
 	if err != nil {
-		fmt.Println(err)
+		log.Error().Err(err)
 		return gr
 	}
 	defer res.Body.Close()
 	if res.StatusCode != 200 {
 		b, err := io.ReadAll(res.Body)
 		if err != nil {
-			log.Fatalln(err)
+			log.Fatal().Err(err).Msg("Can't get rules, and api response body can't be read")
+		} else {
+			log.Error().Str("body", string(b)).Msg("Can't get rules")
 		}
-		fmt.Println(string(b))
 	} else {
-		json.NewDecoder(res.Body).Decode(&gr)
+		err := json.NewDecoder(res.Body).Decode(&gr)
+
+		if err != nil {
+			log.Error().Err(err).Msg("Can't get rules")
+		}
 	}
 
 	return gr
@@ -206,10 +253,16 @@ func existingMetric(query, server string) bool {
 	var qu Query
 
 	if err != nil {
+		log.Error().Err(err).Msg("Can't query VM api")
 		return false
 	}
 	defer res.Body.Close()
-	json.NewDecoder(res.Body).Decode(&qu)
+	err = json.NewDecoder(res.Body).Decode(&qu)
+
+	if err != nil {
+		log.Error().Err(err).Msg("Can't decode VM api response")
+		return false
+	}
 
 	return len(qu.Data.Result) > 0
 }


### PR DESCRIPTION
##  Why

After some debug, I found out that exposed metrics where wrongly generated.

I decided to fix it and do some refacto and enhancement.

## How

- alerting rules are now validated against ranges defined in configuration (instead of 1d, 30d, 90d before)
- exposed metrics are now dynamically based on range in configuration (it was a static 1d, 30d and 90d before)
- exposed metrics labels are now dynamically based on labels in configuration (only `tenant` was available before)
- readme greatly improved
- use of zerolog to improve debugging
- and a lot of optimizations (avoid doublons check, etc.)