### PR TITLE
feat: better crash handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ alertsvalidator_validity_range{range_from="1h",range_to="168h",alertname="my_ale
 
 alertsvalidator_validity_range{range_from="168h",range_to="672h",alertname="my_alert",status="valid"}   1 # Valid
 alertsvalidator_validity_range{range_from="168h",range_to="672h",alertname="my_alert",status="invalid"} 0
+
+alertsvalidator_external_api_error{type="rule", server="https://vmalert.cluster.local."} 0
+alertsvalidator_external_api_error{type="query", server="https://vm.cluster.local./select/000/prometheus"} 0
 ```
 
 ## Logs

--- a/cli/exporter.go
+++ b/cli/exporter.go
@@ -6,7 +6,8 @@ import (
 )
 
 var (
-	gauge *prometheus.GaugeVec
+	gauge           *prometheus.GaugeVec
+	apiErrorCounter *prometheus.CounterVec
 )
 
 func BuildGauge() {
@@ -21,6 +22,16 @@ func BuildGauge() {
 			"range_from",
 			"range_to",
 			"status",
+		}, Conf.LabelKeys...),
+	)
+	apiErrorCounter = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "alertsvalidator_external_api_error",
+			Help: "Are there data fetching errors",
+		},
+		append([]string{
+			"type",
+			"server",
 		}, Conf.LabelKeys...),
 	)
 }


### PR DESCRIPTION
## Why

Before, when alerts-validator wasn't able to fetch data from external servers, it was throwing fatal log and crash.
Now, if api error happen, and error log is trhowed, and dedicated metric counter is increased.

This way, if VM or Prometheus api object are updated and alerts-validator isn't up-to-date anymore, we will see it. 

## How

Add new metric `alertsvalidator_external_api_error`

## Tests

Test will be :heavy_check_mark:  when all PR are merged in parent.

## Related PR

https://github.com/BedrockStreaming/alerts-validator/pull/8
